### PR TITLE
doc: make ogon services start at boot

### DIFF
--- a/doc/build-debian-ubuntu.md
+++ b/doc/build-debian-ubuntu.md
@@ -113,7 +113,7 @@ Then let's start ogon:
 
 ```console
 # Debian stretch/Ubuntu 16.04+
-sudo systemctl start ogon-session-manager
+sudo systemctl enable ogon-rdp-server
 sudo systemctl start ogon-rdp-server
 ```
 


### PR DESCRIPTION
Instruct to enable the service. Only ogon-rdp-server is necessary as it depends on the sesssionManager (and so systemd will start it for us).