### PR TITLE
build: fix build against last FreeRDP 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,6 @@ find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
 
 add_definitions("-DHAVE_CONFIG_H")
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
@@ -115,6 +114,9 @@ set(FREERDP_SERVER_DEPENDENCY_DESCRIPTION "FreeRDP-Server")
 set(FREERDP_SERVER_DEPENDENCY_VERSION "2.0")
 find_dependency(FreeRDP-Server ${FREERDP_SERVER_DEPENDENCY_TYPE} ${FREERDP_SERVER_DEPENDENCY_PURPOSE} ${FREERDP_SERVER_DEPENDENCY_DESCRIPTION} ${FREERDP_SERVER_DEPENDENCY_VERSION})
 include_directories(${FreeRDP-Server_INCLUDE_DIR})
+
+set(CMAKE_REQUIRED_INCLUDES ${WinPR_INCLUDE_DIR} ${FreeRDP_INCLUDE_DIR})
+check_struct_has_member("SURFACE_BITS_COMMAND" "bmp" "freerdp/update.h" HAVE_SURFACECMD_BMP LANGUAGE C)
 
 set(PROTOBUFC_DEPENDENCY_TYPE "REQUIRED")
 set(PROTOBUFC_DEPENDENCY_PURPOSE "Protobuf based RPC - C library")
@@ -153,6 +155,8 @@ if (NOT X11_Xau_FOUND)
 	message(FATAL_ERROR "xauth development files not found")
 endif()
 
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 include (CTest)
 

--- a/config.h.in
+++ b/config.h.in
@@ -9,6 +9,8 @@
 #cmakedefine HAVE_EVENTFD_H
 #cmakedefine HAVE_EPOLL_H
 
+#cmakedefine HAVE_SURFACECMD_BMP
+
 /* Debug */
 #cmakedefine WITH_DEBUG_STATE
 

--- a/rdp-server/graphics.c
+++ b/rdp-server/graphics.c
@@ -590,10 +590,17 @@ int ogon_send_rdp_rfx_bits(ogon_connection *conn, BYTE *data, RDP_RECT *rects,
 	cmd.destTop = 0;
 	cmd.destRight = encoder->desktopWidth;
 	cmd.destBottom = encoder->desktopHeight;
+#ifdef HAVE_SURFACECMD_BMP
+	cmd.bmp.codecID = settings->RemoteFxCodecId;
+	cmd.bmp.bpp = 32;
+	cmd.bmp.width = encoder->desktopWidth;
+	cmd.bmp.height = encoder->desktopHeight;
+#else
 	cmd.codecID = settings->RemoteFxCodecId;
 	cmd.bpp = 32;
 	cmd.width = encoder->desktopWidth;
 	cmd.height = encoder->desktopHeight;
+#endif
 	cmd.skipCompression = TRUE;
 
 	s = encoder->stream;
@@ -618,10 +625,16 @@ int ogon_send_rdp_rfx_bits(ogon_connection *conn, BYTE *data, RDP_RECT *rects,
 
 	rfx_message_free(encoder->rfx_context, message);
 
+#ifdef HAVE_SURFACECMD_BMP
+	cmd.bmp.bitmapDataLength = Stream_GetPosition(s);
+	cmd.bmp.bitmapData = Stream_Buffer(s);
+	messageSize = cmd.bmp.bitmapDataLength;
+#else
 	cmd.bitmapDataLength = Stream_GetPosition(s);
 	cmd.bitmapData = Stream_Buffer(s);
-
 	messageSize = cmd.bitmapDataLength;
+#endif
+
 	messageSize += 22; /* the size of the surface bits command header */
 
 	if (messageSize > settings->MultifragMaxRequestSize) {


### PR DESCRIPTION
Some members of SURFACE_BITS_COMMAND have been moved to the bmp field.