### PR TITLE
build: fix build against last FreeRDP

### DIFF
--- a/rdp-server/backend.c
+++ b/rdp-server/backend.c
@@ -768,12 +768,11 @@ static int ogon_server_set_system_pointer(ogon_connection *connection,
 		ogon_connection *frontConnection = LinkedList_Enumerator_Current(connection->frontConnections);
 
 		if (!msg->clientId || (frontConnection->id == msg->clientId)) {
-			POINTER_SYSTEM_UPDATE *pointer_system;
+			POINTER_SYSTEM_UPDATE pointer_system;
 			rdpPointerUpdate* pointer = frontConnection->context.peer->update->pointer;
 
-			pointer_system = &(pointer->pointer_system);
-			pointer_system->type = msg->ptrType;
-			IFCALL(pointer->PointerSystem, &frontConnection->context, pointer_system);
+			pointer_system.type = msg->ptrType;
+			IFCALL(pointer->PointerSystem, &frontConnection->context, &pointer_system);
 		}
 	}
 

--- a/rdp-server/frontend.c
+++ b/rdp-server/frontend.c
@@ -631,7 +631,7 @@ static BOOL ogon_peer_activate(freerdp_peer *client) {
 		ogon_bitmap_encoder* encoder = front->encoder;
 		ogon_backend_connection *backend;
 		rdpPointerUpdate *pointer = client->update->pointer;
-		POINTER_SYSTEM_UPDATE *systemPointer = &(pointer->pointer_system);
+		POINTER_SYSTEM_UPDATE systemPointer;
 
 		backend = conn->shadowing->backend;
 
@@ -670,8 +670,8 @@ static BOOL ogon_peer_activate(freerdp_peer *client) {
 		}
 
 		/* restore the kind and shape of pointer */
-		systemPointer->type = backend->lastSetSystemPointer;
-		IFCALL(pointer->PointerSystem, client->context, systemPointer);
+		systemPointer.type = backend->lastSetSystemPointer;
+		IFCALL(pointer->PointerSystem, client->context, &systemPointer);
 
 		ogon_connection_clear_pointer_cache(conn);
 		if (backend->haveBackendPointer)

--- a/rdp-server/peer.c
+++ b/rdp-server/peer.c
@@ -570,8 +570,9 @@ static BOOL process_new_shadowing_frontend(ogon_connection *conn, wMessage *msg)
 
 	/* reset the last pointer */
 	if (srcConn->backend->lastSetSystemPointer != backend->lastSetSystemPointer) {
-		pointer->pointer_system.type = backend->lastSetSystemPointer;
-		pointer->PointerSystem(&srcConn->context, &pointer->pointer_system);
+		POINTER_SYSTEM_UPDATE pointer_system;
+		pointer_system.type = backend->lastSetSystemPointer;
+		pointer->PointerSystem(&srcConn->context, &pointer_system);
 	}
 
 	/* force the spy with the last set pointer on the backend */
@@ -597,6 +598,7 @@ static BOOL process_rewire_original_backend(ogon_connection *conn, wMessage *msg
 	ogon_front_connection *front = &conn->front;
 	ogon_backend_connection *backend = conn->backend;
 	rdpSettings *settings = conn->context.settings;
+	POINTER_SYSTEM_UPDATE pointer_system;
 	rdpPointerUpdate* pointer = conn->context.peer->update->pointer;
 
 	BOOL ret = FALSE;
@@ -650,8 +652,8 @@ static BOOL process_rewire_original_backend(ogon_connection *conn, wMessage *msg
 	}
 
 	/* sets back the pointer of the backend */
-	pointer->pointer_system.type = backend->lastSetSystemPointer;
-	pointer->PointerSystem(&conn->context, &pointer->pointer_system);
+	pointer_system.type = backend->lastSetSystemPointer;
+	pointer->PointerSystem(&conn->context, &pointer_system);
 
 	if (backend->haveBackendPointer) {
 		ogon_connection_set_pointer(conn, &backend->lastSetPointer);


### PR DESCRIPTION
Pointer structures have been changed, so that we need to provide our own local variables. This should alss work with "old" FreeRDP 2.0.