### PR TITLE
fix [session-manager]: config file checking with started process

### DIFF
--- a/session-manager/common/config/PropertyManager.cpp
+++ b/session-manager/common/config/PropertyManager.cpp
@@ -366,7 +366,6 @@ namespace ogon { namespace sessionmanager { namespace config {
 
 	bool PropertyManager::checkConfigFile(const std::string &filename) {
 		boost::property_tree::ptree pt;
-		CSGuard guard(&mCSection);
 		try {
 			boost::property_tree::read_ini(filename, pt);
 		} catch (boost::property_tree::file_parser_error &e) {

--- a/session-manager/common/config/PropertyManager.h
+++ b/session-manager/common/config/PropertyManager.h
@@ -66,7 +66,7 @@ namespace ogon { namespace sessionmanager { namespace config {
 
 		bool saveProperties(const std::string &filename);
 		bool loadProperties(const std::string &filename);
-		bool checkConfigFile(const std::string &filename);
+		static bool checkConfigFile(const std::string &filename);
 
 	private:
 		bool parsePropertyGlobal(const std::string &parentPath, const boost::property_tree::ptree &tree,


### PR DESCRIPTION
When the session-manager process was running the config file check
didn't work as the existence of the PID file was checked before.

Now the config file check is done before. As it doesn't require any
class specific variables the check function is now static.