### PR TITLE
ogon_input_unicode_keyboard_event cut/paste typo

### DIFF
--- a/rdp-server/frontend.c
+++ b/rdp-server/frontend.c
@@ -1023,7 +1023,7 @@ static BOOL ogon_input_unicode_keyboard_event(rdpInput* input, UINT16 flags, UIN
 	ogon_connection *conn = (ogon_connection *)input->context;
 	ogon_backend_connection* backend = conn->shadowing->backend;
 
-	if ((conn->front.inputFilter & INPUT_FILTER_KEYBOARD) || !backend || !backend->client.ScancodeKeyboardEvent) {
+	if ((conn->front.inputFilter & INPUT_FILTER_KEYBOARD) || !backend || !backend->client.UnicodeKeyboardEvent) {
 		return TRUE;
 	}
 


### PR DESCRIPTION
checked the wrong backend function which could result in calling a null function if the backend does not provide a unicode keyboard input implementation.