### PR TITLE
adapt to freerdp input capability changes

### DIFF
--- a/rdp-server/frontend.c
+++ b/rdp-server/frontend.c
@@ -1419,6 +1419,10 @@ BOOL ogon_connection_init_front(ogon_connection *conn)
 	settings->TlsSecurity = TRUE;
 	settings->NlaSecurity = FALSE;
 
+	settings->UnicodeInput = TRUE;
+	settings->HasHorizontalWheel = TRUE;
+	settings->HasExtendedMouseEvent = TRUE;
+
 	peer->Capabilities = ogon_peer_capabilities;
 	peer->PostConnect = ogon_peer_post_connect;
 	peer->Activate = ogon_peer_activate;


### PR DESCRIPTION
When building against recent freerdp upstream versions ogon did not receive unicode keyboard input anymore.
Since freerdp commit https://github.com/FreeRDP/FreeRDP/commit/269002f0a15ab9040d37dea1bb7aabb69586e834 the respective settings members are respected when sending the input capabilities.