### PR TITLE
rdpegfx: support for current egfx cap versions

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -210,6 +210,12 @@ If found and set to true a AVC444-capable client will receive an additional chro
 standard H.264 frame. This mode reduces blur effects and improves the readability for certain text colors.
 Note: This setting should only be enabled for highspeed LAN connections.
 
+### ogon_restrictAVC444_bool
+
+Restrict the usage of AVC444 to clients that announce the RDPGFX_CAPS_FLAG_AVC_THINCLIENT flag.
+
+Default: false
+
 ### ogon_bitrate_number
 
 Is the bitrate which should be used (only applies to H.264 for now).

--- a/rdp-server/frontend.c
+++ b/rdp-server/frontend.c
@@ -1382,11 +1382,13 @@ BOOL ogon_connection_init_front(ogon_connection *conn)
 	peer->autodetect->RTTMeasureResponse = ogon_bwmgmt_client_rtt_measure_response;
 
 #ifdef WITH_OPENH264
-	if (PBRPC_SUCCESS == ogon_icp_get_property_bool(conn->id, "ogon.disableGraphicsPipelineH264", &boolValue)) {
-		front->rdpgfxH264Forbidden = boolValue;
-	}
-	if (PBRPC_SUCCESS == ogon_icp_get_property_bool(conn->id, "ogon.enableFullAVC444", &boolValue)) {
-		front->rdpgfxH264EnableFullAVC444 = boolValue;
+	if (!front->rdpgfxForbidden) {
+		if (PBRPC_SUCCESS == ogon_icp_get_property_bool(conn->id, "ogon.disableGraphicsPipelineH264", &boolValue)) {
+			front->rdpgfxH264Forbidden = boolValue;
+		}
+		if (PBRPC_SUCCESS == ogon_icp_get_property_bool(conn->id, "ogon.enableFullAVC444", &boolValue)) {
+			front->rdpgfxH264EnableFullAVC444 = boolValue;
+		}
 	}
 #else
 	front->rdpgfxH264Forbidden = TRUE;
@@ -1453,6 +1455,12 @@ BOOL ogon_connection_init_front(ogon_connection *conn)
 	front->rdpgfx->data = conn;
 	front->rdpgfx->OpenResult = ogon_rdpgfx_open_result;
 	front->rdpgfx->FrameAcknowledge = ogon_rdpgfx_frame_acknowledge;
+
+	if (!front->rdpgfxForbidden) {
+		if (PBRPC_SUCCESS == ogon_icp_get_property_bool(conn->id, "ogon.restrictAVC444", &boolValue)) {
+			front->rdpgfx->avc444Restricted = boolValue;
+		}
+	}
 
 	conn->frontConnections = LinkedList_New();
 	if (!conn->frontConnections)

--- a/rdp-server/rdpgfx.h
+++ b/rdp-server/rdpgfx.h
@@ -74,6 +74,7 @@ struct _rdpgfx_server_context
 	BOOL h264Supported;
 	BOOL avc444Supported;
 	BOOL avc444v2Supported;
+	BOOL avc444Restricted;
 
 	/*** APIs called by the server. ***/
 	/**


### PR DESCRIPTION
Add and handle current capversions up to `RDPGFX_CAPVERSION_106`.
Detect and handle clients using invalid values for `RDPGFX_CAPVERSION_106`.

Add a new config option `ogon_restrictAVC444_bool`:
If set to `true` AVC444 will only be used for clients that send the `RDPGFX_CAPS_FLAG_AVC_THINCLIENT` flag.

This allows to restrict the more demanding AVC444 encoding to clients that really need it.