### PR TITLE
protocol: fix some compilation warnings

### DIFF
--- a/backend/protocol.c
+++ b/backend/protocol.c
@@ -122,8 +122,8 @@ static BOOL ogon_read_version(wStream *s, ogon_msg_version* msg) {
 		return FALSE;
 	}
 
-	msg->versionMajor = proto->major;
-	msg->versionMinor = proto->minor;
+	msg->versionMajor = proto->vmajor;
+	msg->versionMinor = proto->vminor;
 	if (proto->cookie) {
 		msg->cookie = strdup(proto->cookie);
 		if (!msg->cookie) {
@@ -141,8 +141,8 @@ static BOOL ogon_read_version(wStream *s, ogon_msg_version* msg) {
 static int ogon_prepare_version(ogon_msg_version *msg, Ogon__Backend__VersionReply *target) {
 	ogon__backend__version_reply__init(target);
 
-	target->major = msg->versionMajor;
-	target->minor = msg->versionMinor;
+	target->vmajor = msg->versionMajor;
+	target->vminor = msg->versionMinor;
 	target->cookie = msg->cookie;
 
 	return ogon__backend__version_reply__get_packed_size(target);

--- a/protocols/protobuf/SBP.proto
+++ b/protocols/protobuf/SBP.proto
@@ -9,13 +9,13 @@ enum MSGTYPE {
 
 message VersionInfoRequest {
 	required uint32 sessionId = 1;
-	required uint32 major = 2;
-	required uint32 minor = 3;
+	required uint32 vmajor = 2;
+	required uint32 vminor = 3;
 }
 
 message VersionInfoResponse {
-	required uint32 major = 2;
-	required uint32 minor = 3;
+	required uint32 vmajor = 2;
+	required uint32 vminor = 3;
 }
 
 message AuthenticateUserRequest {

--- a/protocols/protobuf/backend.proto
+++ b/protocols/protobuf/backend.proto
@@ -112,8 +112,8 @@ message message {
 }
 
 message versionReply {
-	required uint32 major = 1;
-	required uint32 minor = 2;
+	required uint32 vmajor = 1;
+	required uint32 vminor = 2;
 	optional string cookie = 3;
 }
 

--- a/protocols/protobuf/pbRPC.proto
+++ b/protocols/protobuf/pbRPC.proto
@@ -2,8 +2,8 @@ syntax="proto2";
 package ogon.pbrpc;
 
 message VersionInfo {
-	required uint32 major = 1;
-	required uint32 minor = 2;
+	required uint32 vmajor = 1;
+	required uint32 vminor = 2;
 	optional string cookie = 3;
 }
 

--- a/rdp-server/icp/pbrpc/pbrpc.c
+++ b/rdp-server/icp/pbrpc/pbrpc.c
@@ -408,8 +408,8 @@ static BOOL pbrpc_connect(pbRPCContext* context, DWORD timeout)
 	}
 
 	ogon__pbrpc__version_info__init(&versionInfo);
-	versionInfo.major = OGON_PROTOCOL_VERSION_MAJOR;
-	versionInfo.minor = OGON_PROTOCOL_VERSION_MINOR;
+	versionInfo.vmajor = OGON_PROTOCOL_VERSION_MAJOR;
+	versionInfo.vminor = OGON_PROTOCOL_VERSION_MINOR;
 
 	if (!(message = pbrpc_message_new())) {
 		WLog_ERR(TAG, "error while creating a new pbrpc message, disconnecting!");
@@ -464,16 +464,16 @@ static BOOL pbrpc_connect(pbRPCContext* context, DWORD timeout)
 		goto error_out;
 	}
 
-	if (message->versioninfo->major != OGON_PROTOCOL_VERSION_MAJOR) {
+	if (message->versioninfo->vmajor != OGON_PROTOCOL_VERSION_MAJOR) {
 		WLog_ERR(TAG, "error, ogon-session-manager (protocol %"PRIu32".%"PRIu32") is not compatible with ogon(%u.%u)!",
-			message->versioninfo->major, message->versioninfo->minor,
+			message->versioninfo->vmajor, message->versioninfo->vminor,
 			OGON_PROTOCOL_VERSION_MAJOR, OGON_PROTOCOL_VERSION_MINOR);
 		context->transport->close(context->transport);
 		goto error_out;
 	}
 
 	WLog_DBG(TAG, "Version information received from session-manager: %"PRIu32".%"PRIu32"",
-			message->versioninfo->major, message->versioninfo->minor);
+			message->versioninfo->vmajor, message->versioninfo->vminor);
 
 	ogon__pbrpc__rpcbase__free_unpacked(message, NULL);
 	context->isConnected = TRUE;

--- a/session-manager/common/call/CallInSBPVersion.cpp
+++ b/session-manager/common/call/CallInSBPVersion.cpp
@@ -59,8 +59,8 @@ namespace ogon { namespace sessionmanager { namespace call {
 			return false;
 		}
 		mSessionId = req.sessionid();
-		mVersionMajor = req.major();
-		mVersionMinor = req.minor();
+		mVersionMajor = req.vmajor();
+		mVersionMinor = req.vminor();
 
 		return true;
 	}
@@ -68,8 +68,8 @@ namespace ogon { namespace sessionmanager { namespace call {
 	bool CallInSBPVersion::encodeResponse() {
 		// encode protocol buffers
 		VersionInfoResponse resp;
-		resp.set_major(OGON_PROTOCOL_VERSION_MAJOR);
-		resp.set_minor(OGON_PROTOCOL_VERSION_MINOR);
+		resp.set_vmajor(OGON_PROTOCOL_VERSION_MAJOR);
+		resp.set_vminor(OGON_PROTOCOL_VERSION_MINOR);
 
 		if (!resp.SerializeToString(&mEncodedResponse)) {
 			// failed to serialize

--- a/session-manager/common/pbRPC/RpcEngine.cpp
+++ b/session-manager/common/pbRPC/RpcEngine.cpp
@@ -324,9 +324,9 @@ namespace ogon { namespace pbrpc {
 			}
 
 			WLog_Print(logger_RPCEngine, WLOG_DEBUG, "received ogon version information %" PRIu32 ".%" PRIu32 "",
-						mpbRPC.versioninfo().major(), mpbRPC.versioninfo().minor());
+						mpbRPC.versioninfo().vmajor(), mpbRPC.versioninfo().vminor());
 
-			UINT32 majorversion = mpbRPC.versioninfo().major();
+			UINT32 majorversion = mpbRPC.versioninfo().vmajor();
 
 			std::string serialized;
 
@@ -335,8 +335,8 @@ namespace ogon { namespace pbrpc {
 			mpbRPC.set_tag(callID);
 			mpbRPC.set_msgtype(-1);
 			VersionInfo *info = mpbRPC.mutable_versioninfo();
-			info->set_major(OGON_PROTOCOL_VERSION_MAJOR);
-			info->set_minor(OGON_PROTOCOL_VERSION_MINOR);
+			info->set_vmajor(OGON_PROTOCOL_VERSION_MAJOR);
+			info->set_vminor(OGON_PROTOCOL_VERSION_MINOR);
 
 			mpbRPC.set_status(RPCBase_RPCSTATUS_SUCCESS);
 			mpbRPC.SerializeToString(&serialized);


### PR DESCRIPTION
On Ubuntu 18.04 we get hundreds of warnings like these:

    session-manager/pbRPC.pb.h:138:30: warning:
    In the GNU C Library, "major" is defined by <sys/sysmacros.h>.
    For historical compatibility, it is currently defined by <sys/types.h> as well, but we plan to remove this soon.

Renamed major/minor to vmajor/vminor.