### PR TITLE
fixed some uninitialized FreeRDP structs

### DIFF
--- a/rdp-server/backend.c
+++ b/rdp-server/backend.c
@@ -590,9 +590,9 @@ BOOL ogon_new_pointer_to_mono_color_pointer(POINTER_NEW_UPDATE *pointerNew, BOOL
 
 
 void ogon_connection_set_pointer(ogon_connection *connection, ogon_msg_set_pointer *msg) {
-	POINTER_NEW_UPDATE pointerNew;
-	POINTER_COLOR_UPDATE* pointerColor;
-	POINTER_CACHED_UPDATE pointerCached;
+	POINTER_CACHED_UPDATE pointerCached = { 0 };
+	POINTER_NEW_UPDATE pointerNew = { 0 };
+	POINTER_COLOR_UPDATE* pointerColor = &(pointerNew.colorPtrAttr);
 	BOOL isRdesktop = FALSE;
 	char *clientProductId = connection->context.settings->ClientProductId;
 	rdpPointerUpdate* pointer = connection->context.peer->update->pointer;
@@ -601,8 +601,6 @@ void ogon_connection_set_pointer(ogon_connection *connection, ogon_msg_set_point
 	 * Note: As msg values got already validated in ogon_server_set_pointer()
 	 * there is no need to reverify them here
 	 */
-
-	pointerColor = &(pointerNew.colorPtrAttr);
 
 	pointerColor->cacheIndex = 0;
 	pointerColor->xPos = msg->xPos;
@@ -768,7 +766,7 @@ static int ogon_server_set_system_pointer(ogon_connection *connection,
 		ogon_connection *frontConnection = LinkedList_Enumerator_Current(connection->frontConnections);
 
 		if (!msg->clientId || (frontConnection->id == msg->clientId)) {
-			POINTER_SYSTEM_UPDATE pointer_system;
+			POINTER_SYSTEM_UPDATE pointer_system = { 0 };
 			rdpPointerUpdate* pointer = frontConnection->context.peer->update->pointer;
 
 			pointer_system.type = msg->ptrType;
@@ -790,7 +788,7 @@ static int ogon_server_beep(ogon_connection *connection, ogon_msg_beep *msg) {
 
 	LinkedList_Enumerator_Reset(connection->frontConnections);
 	while (LinkedList_Enumerator_MoveNext(connection->frontConnections)) {
-		PLAY_SOUND_UPDATE playSound;
+		PLAY_SOUND_UPDATE playSound = { 0 };
 		ogon_connection *frontConnection = LinkedList_Enumerator_Current(connection->frontConnections);
 		pPlaySound playSoundCall = frontConnection->context.peer->update->PlaySound;
 

--- a/rdp-server/frontend.c
+++ b/rdp-server/frontend.c
@@ -631,7 +631,7 @@ static BOOL ogon_peer_activate(freerdp_peer *client) {
 		ogon_bitmap_encoder* encoder = front->encoder;
 		ogon_backend_connection *backend;
 		rdpPointerUpdate *pointer = client->update->pointer;
-		POINTER_SYSTEM_UPDATE systemPointer;
+		POINTER_SYSTEM_UPDATE systemPointer = { 0 };
 
 		backend = conn->shadowing->backend;
 
@@ -1038,7 +1038,7 @@ static BOOL ogon_input_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT
 	ogon_connection *conn = (ogon_connection*) input->context;
 	ogon_backend_connection* backend = (ogon_backend_connection *)conn->shadowing->backend;
 	ogon_connection *connection = conn->shadowing;
-	POINTER_POSITION_UPDATE pointerUpdate;
+	POINTER_POSITION_UPDATE pointerUpdate = { 0 };
 
 	if ((conn->front.inputFilter & INPUT_FILTER_MOUSE) || !backend || !backend->client.MouseEvent) {
 		return TRUE;
@@ -1184,7 +1184,7 @@ static BOOL ogon_update_frame_acknowledge(rdpContext *context, UINT32 frameId)
 BOOL ogon_rdpgfx_shutdown(ogon_connection *conn)
 {
 	ogon_front_connection *front = &conn->front;
-	RDPGFX_DELETE_SURFACE_PDU delete_surface;
+	RDPGFX_DELETE_SURFACE_PDU delete_surface = { 0 };
 	if (front->rdpgfxConnected) {
 		WLog_DBG(TAG, "shutting down graphics pipeline channel");
 		if (front->rdpgfxOutputSurface) {
@@ -1203,9 +1203,9 @@ BOOL ogon_rdpgfx_init_output(ogon_connection *conn)
 	ogon_bitmap_encoder *encoder = front->encoder;
 	UINT32 width, height;
 
-	RDPGFX_RESET_GRAPHICS_PDU reset_graphics;
-	RDPGFX_CREATE_SURFACE_PDU create_surface;
-	RDPGFX_MAP_SURFACE_TO_OUTPUT_PDU map_surface_to_output;
+	RDPGFX_RESET_GRAPHICS_PDU reset_graphics = { 0 };
+	RDPGFX_CREATE_SURFACE_PDU create_surface = { 0 };
+	RDPGFX_MAP_SURFACE_TO_OUTPUT_PDU map_surface_to_output = { 0 };
 
 	if (!front->rdpgfxConnected || !encoder) {
 		return TRUE;
@@ -1237,7 +1237,7 @@ BOOL ogon_rdpgfx_init_output(ogon_connection *conn)
 
 #if 0
 	{
-		RDPGFX_SOLID_FILL_PDU solidfill;
+		RDPGFX_SOLID_FILL_PDU solidfill = { 0 };
 		RECTANGLE_16 fillRect;
 		solidfill.surfaceId = front->rdpgfxOutputSurface;
 		solidfill.fillPixel.B = 0xFF;

--- a/rdp-server/graphics.c
+++ b/rdp-server/graphics.c
@@ -197,7 +197,7 @@ int ogon_send_gfx_rfx_progressive_bits(ogon_connection *conn, BYTE *data,
 	wStream *s;
 	UINT32 i;
 	RFX_MESSAGE *message;
-	RDPGFX_WIRE_TO_SURFACE_PDU_2 pdu;
+	RDPGFX_WIRE_TO_SURFACE_PDU_2 pdu = { 0 };
 	RFX_RECT r;
 	ogon_backend_connection *backend = conn->backend;
 	ogon_front_connection *frontend = &conn->front;
@@ -264,7 +264,7 @@ int ogon_send_gfx_rfx_bits(ogon_connection *conn, BYTE *data, RDP_RECT *rects,
 	UINT32 i;
 	RFX_MESSAGE *message;
 	BYTE *buf;
-	RDPGFX_WIRE_TO_SURFACE_PDU_1 pdu;
+	RDPGFX_WIRE_TO_SURFACE_PDU_1 pdu = { 0 };
 	RFX_RECT r;
 	ogon_backend_connection *backend = conn->backend;
 	ogon_front_connection *frontend = &conn->front;
@@ -339,7 +339,7 @@ int ogon_send_gfx_debug_bitmap(ogon_connection *conn) {
 	ogon_bitmap_encoder *encoder = frontend->encoder;
 	BYTE *encodedData = NULL;
 	UINT32 encodedSize;
-	RDPGFX_WIRE_TO_SURFACE_PDU_1 pdu;
+	RDPGFX_WIRE_TO_SURFACE_PDU_1 pdu = { 0 };
 	UINT32 scanLine = encoder->desktopWidth * 4;
 
 	if (!(encodedData = freerdp_bitmap_compress_planar(encoder->debug_context,
@@ -409,7 +409,7 @@ int ogon_send_gfx_h264_bits(ogon_connection *conn, BYTE *data, RDP_RECT *rects,
 	BYTE *encodedData;
 	UINT32 encodedSize;
 	RDP_RECT desktopRect;
-	RDPGFX_WIRE_TO_SURFACE_PDU_1 pdu;
+	RDPGFX_WIRE_TO_SURFACE_PDU_1 pdu = { 0 };
 	wStream *s;
 	BOOL optimizable = FALSE;
 	UINT32 maxFrameRate = (UINT32)conn->fps;
@@ -571,7 +571,7 @@ int ogon_send_rdp_rfx_bits(ogon_connection *conn, BYTE *data, RDP_RECT *rects,
 	 */
 
 	wStream *s;
-	SURFACE_BITS_COMMAND cmd;
+	SURFACE_BITS_COMMAND cmd = { 0 };
 	RFX_MESSAGE* message;
 	UINT32 messageSize;
 
@@ -602,6 +602,7 @@ int ogon_send_rdp_rfx_bits(ogon_connection *conn, BYTE *data, RDP_RECT *rects,
 	cmd.bmp.bpp = 32;
 	cmd.bmp.width = encoder->desktopWidth;
 	cmd.bmp.height = encoder->desktopHeight;
+	cmd.bmp.flags = 0;
 	cmd.skipCompression = TRUE;
 
 	s = encoder->stream;
@@ -661,7 +662,7 @@ int ogon_send_bitmap_bits(ogon_connection *conn, BYTE *data, RDP_RECT *rects,
 	ogon_bmp_context *bmp = encoder->bmpContext;
 	UINT32 updatePduSize, maxPduSize, maxRectSize, maxDataSize;
 	UINT32 i, x, y, nx, ny, numBitmaps, newMaxSize, nextSize;
-	BITMAP_UPDATE bitmapUpdate;
+	BITMAP_UPDATE bitmapUpdate = { 0 };
 	RDP_RECT *pr;
 	RDP_RECT r;
 	BYTE *src;
@@ -1067,17 +1068,17 @@ static inline void ogon_send_frame_marker(ogon_connection *conn, BOOL begin) {
 	if (front->rdpgfxConnected) {
 		/* under gfx frame markers must be supported */
 		if (begin) {
-			RDPGFX_START_FRAME_PDU pdu;
+			RDPGFX_START_FRAME_PDU pdu = { 0 };
 			pdu.frameId = front->nextFrameId;
 			pdu.timestamp = 0;
 			front->rdpgfx->StartFrame(front->rdpgfx, &pdu);
 		} else {
-			RDPGFX_END_FRAME_PDU pdu;
+			RDPGFX_END_FRAME_PDU pdu = { 0 };
 			pdu.frameId = front->nextFrameId;
 			front->rdpgfx->EndFrame(front->rdpgfx, &pdu);
 		}
 	} else if (settings->SurfaceFrameMarkerEnabled && front->codecMode != CODEC_MODE_BMP) {
-		SURFACE_FRAME_MARKER sfm;
+		SURFACE_FRAME_MARKER sfm = { 0 };
 		sfm.frameId = front->nextFrameId;
 		if (begin) {
 			sfm.frameAction = SURFACECMD_FRAMEACTION_BEGIN;

--- a/rdp-server/peer.c
+++ b/rdp-server/peer.c
@@ -570,7 +570,7 @@ static BOOL process_new_shadowing_frontend(ogon_connection *conn, wMessage *msg)
 
 	/* reset the last pointer */
 	if (srcConn->backend->lastSetSystemPointer != backend->lastSetSystemPointer) {
-		POINTER_SYSTEM_UPDATE pointer_system;
+		POINTER_SYSTEM_UPDATE pointer_system = { 0 };
 		pointer_system.type = backend->lastSetSystemPointer;
 		pointer->PointerSystem(&srcConn->context, &pointer_system);
 	}
@@ -598,7 +598,7 @@ static BOOL process_rewire_original_backend(ogon_connection *conn, wMessage *msg
 	ogon_front_connection *front = &conn->front;
 	ogon_backend_connection *backend = conn->backend;
 	rdpSettings *settings = conn->context.settings;
-	POINTER_SYSTEM_UPDATE pointer_system;
+	POINTER_SYSTEM_UPDATE pointer_system = { 0 };
 	rdpPointerUpdate* pointer = conn->context.peer->update->pointer;
 
 	BOOL ret = FALSE;

--- a/rdp-server/rdpgfx.c
+++ b/rdp-server/rdpgfx.c
@@ -320,7 +320,7 @@ static BOOL rdpgfx_server_recv_capabilities(rdpgfx_server_context *rdpgfx, wStre
 }
 
 static BOOL rdpgfx_server_recv_frameack(rdpgfx_server_context *rdpgfx, wStream *s, UINT32 length) {
-	RDPGFX_FRAME_ACKNOWLEDGE_PDU frame_acknowledge;
+	RDPGFX_FRAME_ACKNOWLEDGE_PDU frame_acknowledge = { 0 };
 
 	if (length < 12) {
 		return FALSE;


### PR DESCRIPTION
mstsc aborted with internal error when gfx was disabled in ogon.
The reason was a new flag added to FreeRDP's `SURFACE_BITS_COMMAND` struct which we did not set.
Fixed by initializing `SURFACE_BITS_COMMAND` instances with `{ 0 }`.
Also did this with some other FreeRDP struct instances.

This should fix ogon-project/ogon-project/issues/10