### PR TITLE
Use find_library for detecting openh264

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set(OGON_MODULE_LIB_PATH "${OGON_APP_LIB_PATH}/modules")
 set(OGON_AUTH_MODULE_LIB_PATH "${OGON_APP_LIB_PATH}/auth")
 
 if(WITH_OPENH264)
-	set(OGON_OPENH264_LIBRARY "${OGON_APP_LIB_PATH}/libogon-openh264.so")
+    find_library(OGON_OPENH264_LIBRARY NAMES ogon-openh264 openh264 HINTS ${OGON_APP_LIB_PATH})
 endif()
 
 include(ogonCompilerFlags)


### PR DESCRIPTION
OpeH264 might be in system paths, use these as fallback if we
do not use a custom build.