### PR TITLE
Cleanups/fixes for Xsession startup

### DIFF
--- a/misc/ogonXsession
+++ b/misc/ogonXsession
@@ -2,36 +2,49 @@
 
 CONF_FILE="${HOME}/.config/ogon/desktop"
 XSESSION_DIR="/usr/share/xsessions"
+ENV_FILE="/etc/environment"
+LOCALE_FILE="/etc/default/locale"
 DESKTOP_SESSION=""
 SESSION_COMMAND=""
 
+# Make sure to set the very basic environment
+if [ -r "${ENV_FILE}" ]; then
+	. "${ENV_FILE}"
+fi
+if [ -r "${LOCALE_FILE}" ]; then
+	. "${LOCALE_FILE}"
+fi
+[ -z "$LANG" ] || export LANG
+[ -z "$LC_ALL" ] || export LC_ALL
 
 if [ -z "${OGON_X11_NODBUS}" ] && [ -z "${DBUS_SESSION_BUS_ADDRESS}" ]; then
-	eval `dbus-launch --sh-syntax --exit-with-session`
+	eval $(dbus-launch --sh-syntax --exit-with-session)
 fi
 
 if [ ! -z "${OGON_X11_DESKTOP}" ]; then
-	DESKTOP_SESSION=${OGON_X11_DESKTOP}
+	DESKTOP_SESSION="${OGON_X11_DESKTOP}"
 elif [ -r ${CONF_FILE} ]; then
-	DESKTOP_SESSION=$(cat ${CONF_FILE} | tr -d '\n')
+	DESKTOP_SESSION="$(cat ${CONF_FILE} | tr -d '\n')"
 fi
 
 if [ ! -z ${DESKTOP_SESSION} ] && [ -r "${XSESSION_DIR}/${DESKTOP_SESSION}.desktop" ]; then
-	SESSION_COMMAND=$(grep -e '^Exec=' "${XSESSION_DIR}/${DESKTOP_SESSION}.desktop" | tr -d '\n' | cut -d "=" -f 2-)
+	SESSION_COMMAND="$(grep -e '^Exec=' "${XSESSION_DIR}/${DESKTOP_SESSION}.desktop" | tr -d '\n' | cut -d "=" -f 2-)"
 fi
 
-export DESKTOP_SESSION=${DESKTOP_SESSION}
-export GDMSESSION=${DESKTOP_SESSION}
-export XDG_SESSION_DESKTOP=${DESKTOP_SESSION}
+# Option passed to Xsession needs to have 1 argument only
+export DESKTOP_SESSION="${DESKTOP_SESSION}"
+export GDMSESSION="${DESKTOP_SESSION}"
+export XDG_SESSION_DESKTOP="${DESKTOP_SESSION}"
 
+# SESSION_COMMAND should be one argument - will be parsed later
 if [ -r /etc/X11/Xsession ]; then
-  . /etc/X11/Xsession ${SESSION_COMMAND}
+  . /etc/X11/Xsession "${SESSION_COMMAND}"
 elif [ -r /etc/X11/xdm/Xsession ]; then
-  . /etc/X11/xdm/Xsession ${SESSION_COMMAND}
+  . /etc/X11/xdm/Xsession "${SESSION_COMMAND}"
 elif [ -r /etc/gdm/Xsession ]; then
-  /etc/gdm/Xsession ${SESSION_COMMAND}
+  /etc/gdm/Xsession "${SESSION_COMMAND}"
 elif [ -r /etc/X11/xinit/Xsession ]; then
-  . /etc/X11/xinit/Xsession ${SESSION_COMMAND}
+  . /etc/X11/xinit/Xsession "${SESSION_COMMAND}"
 elif [ -r /etc/X11/xinit/xinitrc ]; then
-  . /etc/X11/xinit/xinitrc ${SESSION_COMMAND}
+  . /etc/X11/xinit/xinitrc "${SESSION_COMMAND}"
 fi


### PR DESCRIPTION
Make sure there is a basic environment (LANG, etc.) otherwise
tools (like gnome-terminal) will fail to start.
Make the called session *one* argument - this will be parsed
later on. Otherwise you'll get errors when calling a session
containin an Exec= line with more than one argument in a
xsession file.