### PR TITLE
ogon-rdp-server: fix an overflow in the length of ICP message (no security issue)

### DIFF
--- a/rdp-server/icp/pbrpc/pbrpc.c
+++ b/rdp-server/icp/pbrpc/pbrpc.c
@@ -190,7 +190,7 @@ static int pbrpc_process_response(pbRPCContext* context, Ogon__Pbrpc__RPCBase *r
 static int pbrpc_process_message_out(pbRPCContext* context, Ogon__Pbrpc__RPCBase *msg)
 {
 	int ret;
-	char msgLen = ogon__pbrpc__rpcbase__get_packed_size(msg);
+	int msgLen = ogon__pbrpc__rpcbase__get_packed_size(msg);
 	char *buf = malloc(msgLen);
 	if (!buf)
 		return -1;


### PR DESCRIPTION
There were a stupid bug with the packed size being temporary stored in a signed char.
So when the size of the payload was exceeding 127, it was becoming negative, leading to a failing (and silent) malloc, leading to that mysterious behaviour with messages bigger than 127 bytes, not being sent.