### PR TITLE
Add pulseaudio session environment

### DIFF
--- a/misc/ogon-start-vc.sh.in
+++ b/misc/ogon-start-vc.sh.in
@@ -17,11 +17,16 @@ if [ -x "$RDPDR" ]; then
 fi
 
 # rdp audio
-PULSE=@OGON_BIN_PATH@/pulseaudio
+if [ -x @OGON_BIN_PATH@/pulseaudio ]; then
+	PULSE=@OGON_BIN_PATH@/pulseaudio
+else
+	PULSE=/usr/bin/pulseaudio
+fi
 if [ -x "$PULSE" ] && [ ! -z "$OGON_SID" ]; then
-        export PULSE_RUNTIME_PATH="/tmp/.rdpsnd-$OGON_SID/"
-        export PULSE_STATE_PATH="$PULSE_RUNTIME_PATH"
-        export HOME="$PULSE_RUNTIME_PATH"
+	# Exported by launcher:
+        #	PULSE_CONFIG_PATH
+        #	PULSE_RUNTIME_PATH
+        #	PULSE_STATE_PATH
         $PULSE --start --log-target=syslog
 	# Options:
 	#	--log-target=[auto|syslog|stderr|file:PATH|newfile:PATH]

--- a/session-manager/common/session/Session.cpp
+++ b/session-manager/common/session/Session.cpp
@@ -324,6 +324,22 @@ namespace ogon { namespace sessionmanager { namespace session {
 			}
 		}
 
+		if (!SetEnvironmentVariableEBA(&mpEnvBlock, "PULSE_CONFIG_PATH", "/etc/ogon/pulse/")) {
+			WLog_Print(logger_Session, WLOG_ERROR, "s %" PRIu32 ": failed to set PULSE_CONFIG_PATH in the environment block", mSessionID);
+			return false;
+		}
+
+		sprintf_s(envstr, sizeof(envstr), "/tmp/.rdpsnd-%" PRIu32 "", mSessionID);
+		if (!SetEnvironmentVariableEBA(&mpEnvBlock, "PULSE_RUNTIME_PATH", envstr)) {
+			WLog_Print(logger_Session, WLOG_ERROR, "s %" PRIu32 ": failed to set PULSE_RUNTIME_PATH in the environment block", mSessionID);
+			return false;
+		}
+
+		if (!SetEnvironmentVariableEBA(&mpEnvBlock, "PULSE_STATE_PATH", envstr)) {
+			WLog_Print(logger_Session, WLOG_ERROR, "s %" PRIu32 ": failed to set PULSE_STATE_PATH in the environment block", mSessionID);
+			return false;
+		}
+
 		mUserUID = pwnam->pw_uid;
 		mGroupUID = pwnam->pw_gid;
 


### PR DESCRIPTION
Instead of creating the pulseaudio environment within the virtual channel script, make ogon itself export the required variables.

When created by the virtual channel script the variables are not exported to the session, so tools may be looking for the wrong pulseaudio server (if multiple are available - like for the default user in current Ubuntu installations).

Exporting it by ogon makes these settings available to the whole session (including the virtual channel script).

One thing that could be improved (though I didn't observer problems with the current implementation): The variables could be set only if the client requested audio. However I have no idea how to achieve that.