### PR TITLE
Add options to relocate session config files

### DIFF
--- a/misc/config.ini.debian.in
+++ b/misc/config.ini.debian.in
@@ -16,7 +16,9 @@ module_xsession_displayOffset_number=100
 module_xsession_uselauncher_bool=true
 module_xsession_startwm_string=@OGON_CFG_PATH@/ogonXsession
 module_xsession_launcherexecutable_string=@OGON_SBIN_PATH@/ogon-backend-launcher
-#module_xsession_xauthoritypath_string=/tmp
+module_xsession_startvc_string=@OGON_BIN_PATH@/ogon-start-vc.sh
+#module_xsession_tmpdir_string=/tmp
+#module_xsession_pulseconfig_string=/etc/ogon/pulse
 
 # Weston configuration
 module_weston_modulename_string=Weston

--- a/misc/config.ini.debian.in
+++ b/misc/config.ini.debian.in
@@ -17,7 +17,7 @@ module_xsession_uselauncher_bool=true
 module_xsession_startwm_string=@OGON_CFG_PATH@/ogonXsession
 module_xsession_launcherexecutable_string=@OGON_SBIN_PATH@/ogon-backend-launcher
 module_xsession_startvc_string=@OGON_BIN_PATH@/ogon-start-vc.sh
-#module_xsession_tmpdir_string=/tmp
+#module_xsession_tmppath_string=/tmp
 #module_xsession_paconfpath_string=/etc/ogon/pulse
 
 # Weston configuration

--- a/misc/config.ini.debian.in
+++ b/misc/config.ini.debian.in
@@ -18,7 +18,7 @@ module_xsession_startwm_string=@OGON_CFG_PATH@/ogonXsession
 module_xsession_launcherexecutable_string=@OGON_SBIN_PATH@/ogon-backend-launcher
 module_xsession_startvc_string=@OGON_BIN_PATH@/ogon-start-vc.sh
 #module_xsession_tmpdir_string=/tmp
-#module_xsession_pulseconfig_string=/etc/ogon/pulse
+#module_xsession_paconfpath_string=/etc/ogon/pulse
 
 # Weston configuration
 module_weston_modulename_string=Weston

--- a/session-manager/module/X11/x11_module.cpp
+++ b/session-manager/module/X11/x11_module.cpp
@@ -529,7 +529,7 @@ static char *x11_rds_module_start(RDS_MODULE_COMMON *module) {
 	}
 
 	if (getPropertyStringWrapper(module->baseConfigPath, &gConfig,
-	                             module->sessionId, "xauthoritypath", buf, sizeof(buf))) {
+	                             module->sessionId, "tmppath", buf, sizeof(buf))) {
 		WLog_Print(gModuleLog, WLOG_DEBUG, "config: xAuthorityPath = %s", buf);
 		sprintf_s(xauthFileName, sizeof(xauthFileName), "%s/.Xauthority.ogon", buf);
 	} else {


### PR DESCRIPTION
Next try:

Tried to get away from the hardcoded paths.
Use temporary path for all temp files
Add config option for ogon pulseaudio config path

This patch obsoletes/reverts/includes the former relocate .xAuthority only patch