### PR TITLE
Added loglevel 'trace' option

### DIFF
--- a/rdp-server/ogon.c
+++ b/rdp-server/ogon.c
@@ -459,7 +459,9 @@ static void parseCommandLine(int argc, char **argv, int *no_daemon, int *kill_pr
 			}
 		}
 		CommandLineSwitchCase(arg, "loglevel") {
-			if (!strcasecmp(arg->Value, "debug")) {
+			if (!strcasecmp(arg->Value, "trace")) {
+				*log_level = WLOG_TRACE;
+			} else if (!strcasecmp(arg->Value, "debug")) {
 				*log_level = WLOG_DEBUG;
 			} else if (!strcasecmp(arg->Value, "info")) {
 				*log_level = WLOG_INFO;

--- a/session-manager/main.cpp
+++ b/session-manager/main.cpp
@@ -234,7 +234,9 @@ void parseCommandLine(int argc, char **argv, int &no_daemon, int &kill_process, 
 			}
 		}
 		CommandLineSwitchCase(arg, "loglevel") {
-			if (!strcasecmp(arg->Value, "debug")) {
+			if (!strcasecmp(arg->Value, "trace")) {
+				log_level = WLOG_TRACE;
+			} else if (!strcasecmp(arg->Value, "debug")) {
 				log_level = WLOG_DEBUG;
 			} else if (!strcasecmp(arg->Value, "info")) {
 				log_level = WLOG_INFO;


### PR DESCRIPTION
While debugging I found several log entries to be on LEVEL WLOG_TRACE.
However --loglevel=trace is not available.
This patch adds loglevel "trace"