### PR TITLE
Make xauthority file name unique

### DIFF
--- a/session-manager/module/X11/x11_module.cpp
+++ b/session-manager/module/X11/x11_module.cpp
@@ -531,7 +531,7 @@ static char *x11_rds_module_start(RDS_MODULE_COMMON *module) {
 	if (getPropertyStringWrapper(module->baseConfigPath, &gConfig,
 	                             module->sessionId, "xauthoritypath", buf, sizeof(buf))) {
 		WLog_Print(gModuleLog, WLOG_DEBUG, "config: xAuthorityPath = %s", buf);
-		sprintf_s(xauthFileName, sizeof(xauthFileName), "%s/.Xauthority.ogon", buf);
+		sprintf_s(xauthFileName, sizeof(xauthFileName), "%s/.Xauthority.ogon.%" PRIu32 "", buf, SessionId);
 	} else {
 		tmpLen = GetEnvironmentVariableEBA(module->envBlock, "HOME", NULL, 0);
 		if (tmpLen) {


### PR DESCRIPTION
This patch fixes a bug introduced with my patch (to modify the location of .Xauthority file).

When not located in a users (unique) home directory the file names need to differ (so I appended to Ogon session Id).